### PR TITLE
Xyberviri

### DIFF
--- a/SQF/dayz_code/actions/pickLock.sqf
+++ b/SQF/dayz_code/actions/pickLock.sqf
@@ -6,6 +6,8 @@ if (player getVariable["PickingInProgress",false])
         diag_log "DZU_PickLock ERROR: Picking Already In Progress!"; 
     };
 
+player removeAction unleashed_hack_garage;
+unleashed_hack_garage = -1; 
 
 _args                   = _this select 3;
 _onComplete             = _args select 1;


### PR DESCRIPTION
Added pick lock script, accepts 4 arguments:
 0 is always cursorTarget (either use cursorTarget or your reference, See below)
 1 is the "name" of a function to call upon success. (Optional:not sure why this would make it useless)
 2 is the "name" of a function to call upon failure.    (Optional)
 3 is the "name" of a function to call upon interrupt.(Optional)

Arguments 1,2 & 3 have access to _cursorTarget which is passed from argument 0 and stored upon execution. It does not actually have to be a cursorTarget, it can be any valid object. 

//Adding action with all 3 features
player addAction [_text,"\z\addons\dayz_code\actions\pickLock.sqf",[cursorTarget,"fnc_on_pass","fnc_on_fail","fnc_on_interrupt"],1,false,true,"",""];

//action with only success feature
player addAction [_text,"\z\addons\dayz_code\actions\pickLock.sqf",[cursorTarget,"fnc_on_pass","",""],1,false,true,"",""];

//how to pass _cursorTarget to the delayed executed fnc_on_pass function.
player addAction [_text,"\z\addons\dayz_code\actions\pickLock.sqf",[cursorTarget,"{_cursorTarget call fnc_on_pass}","",""],1,false,true,"",""];

//Example of executed {CODE} 
player addAction [_text,"\z\addons\dayz_code\actions\pickLock.sqf",[cursorTarget,"{hint ""TACO""}","{hint ""BELL""}","{hint ""GRANDE""}"],1,false,true,"",""];
