### PR TITLE
Added g_pickFailChance_dzu variable to mission file so server owner can

### DIFF
--- a/SQF/dayz_1.chernarus/init.sqf
+++ b/SQF/dayz_1.chernarus/init.sqf
@@ -12,6 +12,9 @@ unleashed_pvSaveInterval = 10; //Send a signal to the server to when this many s
 unleashed_pvSaveStackSize = 2; //Send a signal to the server when the variable stack is larger than this value, when a player variable has changed. default 2
 //Larger stacks are better for performance but may result in desync between multiple variables, 2 is the minimum recommended size. 
 
+g_pickFailChance_dzu = 10;//PickLock Fail chance per second of picking.
+//Every second of picking adds 1% chance of failure. 
+
 // These variables work with the Unleashed movement system and is a way for you to adjust the Zeds/dogs. 
 //Range = the distance between the player and the zeds/dogs and is used in the calculation of the speed and movement distance of the zeds/dogs. 
 //Speed = how fast they should move in each of the agro ranges, variables with the work Distance indicate speeds above the range check. 

--- a/SQF/dayz_1.napf/init.sqf
+++ b/SQF/dayz_1.napf/init.sqf
@@ -12,6 +12,9 @@ unleashed_pvSaveInterval = 10; //Send a signal to the server to when this many s
 unleashed_pvSaveStackSize = 2; //Send a signal to the server when the variable stack is larger than this value, when a player variable has changed. default 2
 //Larger stacks are better for performance but may result in desync between multiple variables, 2 is the minimum recommended size. 
 
+g_pickFailChance_dzu = 10;//PickLock Fail chance per second of picking.
+//Every second of picking adds 1% chance of failure. 
+
 // These variables work with the Unleashed movement system and is a way for you to adjust the Zeds/dogs. 
 //Range = the distance between the player and the zeds/dogs and is used in the calculation of the speed and movement distance of the zeds/dogs. 
 //Speed = how fast they should move in each of the agro ranges, variables with the work Distance indicate speeds above the range check. 

--- a/SQF/dayz_1.takistan/init.sqf
+++ b/SQF/dayz_1.takistan/init.sqf
@@ -12,6 +12,9 @@ unleashed_pvSaveInterval = 10; //Send a signal to the server to when this many s
 unleashed_pvSaveStackSize = 2; //Send a signal to the server when the variable stack is larger than this value, when a player variable has changed. default 2
 //Larger stacks are better for performance but may result in desync between multiple variables, 2 is the minimum recommended size. 
 
+g_pickFailChance_dzu = 10;//PickLock Fail chance per second of picking.
+//Every second of picking adds 1% chance of failure. 
+
 // These variables work with the Unleashed movement system and is a way for you to adjust the Zeds/dogs. 
 //Range = the distance between the player and the zeds/dogs and is used in the calculation of the speed and movement distance of the zeds/dogs. 
 //Speed = how fast they should move in each of the agro ranges, variables with the work Distance indicate speeds above the range check. 

--- a/SQF/dayz_1.utes/init.sqf
+++ b/SQF/dayz_1.utes/init.sqf
@@ -12,6 +12,9 @@ unleashed_pvSaveInterval = 10; //Send a signal to the server to when this many s
 unleashed_pvSaveStackSize = 2; //Send a signal to the server when the variable stack is larger than this value, when a player variable has changed. default 2
 //Larger stacks are better for performance but may result in desync between multiple variables, 2 is the minimum recommended size. 
 
+g_pickFailChance_dzu = 10;//PickLock Fail chance per second of picking.
+//Every second of picking adds 1% chance of failure. 
+
 // These variables work with the Unleashed movement system and is a way for you to adjust the Zeds/dogs. 
 //Range = the distance between the player and the zeds/dogs and is used in the calculation of the speed and movement distance of the zeds/dogs. 
 //Speed = how fast they should move in each of the agro ranges, variables with the work Distance indicate speeds above the range check. 

--- a/SQF/dayz_1.zargabad/init.sqf
+++ b/SQF/dayz_1.zargabad/init.sqf
@@ -12,6 +12,9 @@ unleashed_pvSaveInterval = 10; //Send a signal to the server to when this many s
 unleashed_pvSaveStackSize = 2; //Send a signal to the server when the variable stack is larger than this value, when a player variable has changed. default 2
 //Larger stacks are better for performance but may result in desync between multiple variables, 2 is the minimum recommended size. 
 
+g_pickFailChance_dzu = 10;//PickLock Fail chance per second of picking.
+//Every second of picking adds 1% chance of failure. 
+
 // These variables work with the Unleashed movement system and is a way for you to adjust the Zeds/dogs. 
 //Range = the distance between the player and the zeds/dogs and is used in the calculation of the speed and movement distance of the zeds/dogs. 
 //Speed = how fast they should move in each of the agro ranges, variables with the work Distance indicate speeds above the range check. 

--- a/SQF/dayz_code/actions/pickLock.sqf
+++ b/SQF/dayz_code/actions/pickLock.sqf
@@ -21,8 +21,11 @@ _requiredItems          = ["ItemToolbox"];                                     /
 _searchEXP              = "Generic_Engineering";                               //exp reward
 _searchSkillCurve       = 11.8;                                                //Player skill divide by this skill to reduce total search time.  
 _searchMinTick          = 3;                                                   //Absolute minimum time required to search
-_failChance             = 10;                                                  //Chance to fail per second of searching.
-    _searchTime = ( 
+_failChance             = g_pickFailChance_dzu-1;                              //Chance to fail per second of searching.
+
+if((count _args)>4)then{_failChance=_args select 4;};						   //Allow failchance override via script call.
+
+        _searchTime = ( 
                     (round(_searchTime/(1+(_playerSkill/_searchSkillCurve))) max _searchMinTick)
                 ); 
     player setVariable["PickingInProgress", true, false];
@@ -38,7 +41,7 @@ if({_x in items player||_x in magazines player||_x in weapons player} count _req
         //null = [player,10,true,(getPosATL player)] spawn player_alertZombies;
         sleep 1;
         //roll failure
-        _fail = ((floor(random(100))) < _failChance);
+        _fail = ((floor(random(100))) < _failChance + _x);
         //check search
         if(
                ((_location distance (getPosATL player)) > 0.5 )


### PR DESCRIPTION
change base pick chance.
Added 5th param to pickLock.sqf action script to allow for base pick
chance override via action call.

player addAction [_text,"\z\addons\dayz_code\actions\pickLock.sqf",[cursorTarget,"fnc_on_pass","fnc_on_fail","fnc_on_interrupt",100],1,false,true,"",""]; 
100 is optional and would set the failure rate to 100% on every attempt (only this one call). 
